### PR TITLE
Ensure we adjust modtime on unchanged files.

### DIFF
--- a/dstoreutils.go
+++ b/dstoreutils.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"sort"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -59,6 +60,13 @@ func (s *Server) writeToDir(ctx context.Context, dir, file string, toWrite *pb.R
 		}
 	} else if err != nil {
 		return err
+	} else {
+		// Here adjust the mod time to ensure the file is not deleted
+		newModTime := time.Now()
+		err = os.Chtimes(filepath, newModTime, newModTime)
+		if err != nil {
+			return err
+		}
 	}
 	s.CtxLog(ctx, fmt.Sprintf("Written %v", filepath))
 


### PR DESCRIPTION
Currently we don't overwrite files if the hash is the same as an existing
file. This leads to issues when we clean the dir since we may delete
the current file as it's old, but we should rather keep it. Change
the behaviour to adjust  the date on unchanged files to prevent this.